### PR TITLE
Fix namespace variable

### DIFF
--- a/src/VolcanoCyber.cpp
+++ b/src/VolcanoCyber.cpp
@@ -13,6 +13,8 @@
 #include <ArduinoJson.h>
 #include "translations.h"
 
+using namespace VolcanoTranslations;
+
 // Color Definitions
 constexpr uint16_t  BLACK = 0x0000;
 constexpr uint16_t  RED   = 0xF800;
@@ -113,7 +115,7 @@ AsyncWebServer server(80);      // Web server instance
 WiFiClient mqttWiFiClient;
 PubSubClient mqttClient(mqttWiFiClient);
 
-String currentLang = "de";
+String VolcanoTranslations::currentLang = "de";
 
 // Functions
 String t(const String& key) {

--- a/src/translations.h
+++ b/src/translations.h
@@ -4,7 +4,7 @@
 #include <StreamString.h>
 
 namespace VolcanoTranslations {
-  extern String currentLang = "de";
+  extern String currentLang;
 } // namespace VolcanoTranslations
 
 const std::map<String, std::map<String, String>> translations = {


### PR DESCRIPTION
## Summary
- fix incorrect `currentLang` declaration in `translations.h`
- align variable definition in `VolcanoCyber.cpp`

## Testing
- `g++ -fsyntax-only src/VolcanoCyber.cpp` *(fails: Arduino.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_683ff9b516548329bf0274ea32e653cb